### PR TITLE
Upgrading Selenium to 2.28

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,13 +157,13 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-server-standalone</artifactId>
-      <version>2.25.0</version>
+      <version>2.28.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <version>2.25.0</version>
+      <version>2.28.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/test-client/pom.xml
+++ b/test-client/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.seleniumhq.selenium</groupId>
       <artifactId>selenium-java</artifactId>
-      <version>2.15.0</version>
+      <version>2.28.0</version>
     </dependency>
   </dependencies>
   <repositories>


### PR DESCRIPTION
Selenium 2.28 fixes issues with Firefox support
