### PR TITLE
remove "-host" for bind on all ip (0.0.0.0)

### DIFF
--- a/src/main/java/hudson/plugins/selenium/PluginImpl.java
+++ b/src/main/java/hudson/plugins/selenium/PluginImpl.java
@@ -212,9 +212,9 @@ public class PluginImpl extends Plugin implements Action, Serializable, Describa
             args.add("-throwOnCapabilityNotPresent");
             args.add(Boolean.toString(getThrowOnCapabilityNotPresent()));
         }
-
-        args.add("-host");
-        args.add(getMasterHostName());
+//remove "-host" for bind on all ip (0.0.0.0)
+//        args.add("-host");
+//        args.add(getMasterHostName());
 
         hubLauncher = channel.callAsync(new HubLauncher(port, args.toArray(new String[args.size()]), logLevel));
 


### PR DESCRIPTION
when run jenkins on docker container
if selenium hub bind on all ip ,thenwet using docker host ip  at "Hostname resolver" (Use a fixed hostname )