### PR TITLE
bump selenium version number to version 2.53.0 available since 2016-03-15

### DIFF
--- a/dist-server-standalone/pom.xml
+++ b/dist-server-standalone/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.seleniumhq.selenium</groupId>
-  <artifactId>selenium-server-standalone</artifactId>
+  <artifactId>selenium-java</artifactId>
   <packaging>pom</packaging>
   <version>2.53.0</version>
   <name>Selenium Server Standalone</name>

--- a/dist-server-standalone/pom.xml
+++ b/dist-server-standalone/pom.xml
@@ -6,7 +6,7 @@
   <groupId>org.seleniumhq.selenium</groupId>
   <artifactId>selenium-server-standalone</artifactId>
   <packaging>pom</packaging>
-  <version>2.35.0</version>
+  <version>2.53.0</version>
   <name>Selenium Server Standalone</name>
 
   <properties>

--- a/install.sh
+++ b/install.sh
@@ -2,5 +2,5 @@ version=2.53.0
 #cmd=install:install-file
 cmd=deploy:deploy-file
 mvn $cmd -Dfile=$HOME/Downloads/selenium-server-standalone-${version}.jar \
-    -DgroupId=org.seleniumhq.selenium -DartifactId=selenium-server-standalone -Dversion=${version} -Dpackaging=jar \
+    -DgroupId=org.seleniumhq.selenium -DartifactId=selenium-java -Dversion=${version} -Dpackaging=jar \
     -DrepositoryId=maven.jenkins-ci.org -Durl=http://maven.jenkins-ci.org:8081/content/repositories/releases 

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-version=2.40.0
+version=2.53.0
 #cmd=install:install-file
 cmd=deploy:deploy-file
 mvn $cmd -Dfile=$HOME/Downloads/selenium-server-standalone-${version}.jar \

--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.seleniumhq.selenium</groupId>
-			<artifactId>selenium-server-standalone</artifactId>
+			<artifactId>selenium-java</artifactId>
 			<version>${selenium.version}</version>
 		</dependency>
 	</dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<selenium.short.version>2.46</selenium.short.version>
+		<selenium.short.version>2.52</selenium.short.version>
 		<selenium.version>${selenium.short.version}.0</selenium.version>
 	</properties>
 	<artifactId>selenium</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	</parent>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<selenium.short.version>2.52</selenium.short.version>
+		<selenium.short.version>2.53</selenium.short.version>
 		<selenium.version>${selenium.short.version}.0</selenium.version>
 	</properties>
 	<artifactId>selenium</artifactId>


### PR DESCRIPTION
Bump all selenium version numbers found to 2.53.0.
I am unsure if I got all version numbers, perhaps some duplication should be removed as it is unclear which version number actually counts for the installed version.