### PR TITLE
Bump selenium version to latest available on maven version 2.48.2

### DIFF
--- a/dist-server-standalone/pom.xml
+++ b/dist-server-standalone/pom.xml
@@ -6,10 +6,13 @@
   <groupId>org.seleniumhq.selenium</groupId>
   <artifactId>selenium-server-standalone</artifactId>
   <packaging>pom</packaging>
-  <version>2.35.0</version>
+  <version>${selenium.version}</version>
+
   <name>Selenium Server Standalone</name>
 
   <properties>
+      <selenium.short.version>2.47</selenium.short.version>
+      <selenium.version>${selenium.short.version}.1</selenium.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 
@@ -27,8 +30,8 @@
             </goals>
             <configuration>
               <target>
-                <get src="http://selenium.googlecode.com/files/selenium-server-standalone-${project.version}.jar"
-                     dest="${project.build.directory}/selenium-server-standalone-${project.version}.jar"
+                <get src="http://selenium-release.storage.googleapis.com/${selenium.short.version}/selenium-server-standalone-${selenium.version}.jar"
+                     dest="${project.build.directory}/selenium-server-standalone-${selenium.version}.jar"
                      verbose="on"
                      usetimestamp="true"
                 />

--- a/dist-server-standalone/pom.xml
+++ b/dist-server-standalone/pom.xml
@@ -11,8 +11,8 @@
   <name>Selenium Server Standalone</name>
 
   <properties>
-      <selenium.short.version>2.47</selenium.short.version>
-      <selenium.version>${selenium.short.version}.1</selenium.version>
+      <selenium.short.version>2.53</selenium.short.version>
+      <selenium.version>${selenium.short.version}.0</selenium.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
-version=2.40.0
+version=2.53.0
 #cmd=install:install-file
 cmd=deploy:deploy-file
 mvn $cmd -Dfile=$HOME/Downloads/selenium-server-standalone-${version}.jar \
     -DgroupId=org.seleniumhq.selenium -DartifactId=selenium-server-standalone -Dversion=${version} -Dpackaging=jar \
-    -DrepositoryId=maven.jenkins-ci.org -Durl=http://maven.jenkins-ci.org:8081/content/repositories/releases 
+    -DrepositoryId=maven.jenkins-ci.org -Durl=http://maven.jenkins-ci.org:8081/content/repositories/releases

--- a/pom.xml
+++ b/pom.xml
@@ -9,8 +9,8 @@
 	</parent>
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<selenium.short.version>2.46</selenium.short.version>
-		<selenium.version>${selenium.short.version}.0</selenium.version>
+		<selenium.short.version>2.48</selenium.short.version>
+		<selenium.version>${selenium.short.version}.2</selenium.version>
 	</properties>
 	<artifactId>selenium</artifactId>
 	<version>2.4.2-SNAPSHOT</version>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<configuration>
-						<forkMode>never</forkMode>
+						<forkCount>0</forkCount>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/src/test/java/hudson/plugins/selenium/SeleniumTest.java
+++ b/src/test/java/hudson/plugins/selenium/SeleniumTest.java
@@ -141,7 +141,7 @@ public class SeleniumTest {
 
 	private void waitForRC() throws Exception {
         getPlugin().waitForHubLaunch();
-        for (int i = 0; i < 100; i++) {
+        for (int i = 0; i < 50; i++) {
             Collection<SeleniumTestSlotGroup> slots = getPlugin().getRemoteControls();
             if (!slots.isEmpty()) {
             	//Thread.currentThread().setContextClassLoader(new URLClassLoader(new URL[] { Which.classFileUrl(Hub.class) }, ClassLoader.getSystemClassLoader()));


### PR DESCRIPTION
Merge with #50 
Bump distribution pom version to 2.53.0 in preperation of updating to the actual latest version
For now update to version 2.48.2 that is available in the jenkins maven repo in case someone with commit access but not maven repo access sees this pr and can build a new plugin release with it.
Also replace surefire forkMode with forkCount since it's deprecated.