### PR TITLE
Multiple code improvements - squid:S1213, common-java:DuplicatedBlocks, squid:S00117, squid:S1444, squid:ClassVariableVisibilityCheck

### DIFF
--- a/src/main/java/hudson/plugins/selenium/ComputerListenerImpl.java
+++ b/src/main/java/hudson/plugins/selenium/ComputerListenerImpl.java
@@ -20,6 +20,8 @@ import java.io.Serializable;
 @Extension
 public class ComputerListenerImpl extends ComputerListener implements Serializable {
 
+    private static final long serialVersionUID = 1L;
+
     /**
      * Starts a selenium Grid node remotely.
      */
@@ -35,7 +37,5 @@ public class ComputerListenerImpl extends ComputerListener implements Serializab
         } catch (Throwable e) {
         }
     }
-
-    private static final long serialVersionUID = 1L;
 
 }

--- a/src/main/java/hudson/plugins/selenium/HubHolder.java
+++ b/src/main/java/hudson/plugins/selenium/HubHolder.java
@@ -9,5 +9,13 @@ import org.openqa.grid.web.Hub;
  */
 public class HubHolder {
 
-    public static Hub hub;
+    private static Hub hub;
+
+    public static Hub getHub() {
+        return hub;
+    }
+
+    public static void setHub(Hub hub) {
+        HubHolder.hub = hub;
+    }
 }

--- a/src/main/java/hudson/plugins/selenium/HubLauncher.java
+++ b/src/main/java/hudson/plugins/selenium/HubLauncher.java
@@ -37,21 +37,21 @@ public class HubLauncher extends MasterToSlaveCallable<Void, Exception> {
 
     public Void call() {
         try {
-            Logger LOG = Logger.getLogger(HubLauncher.class.getName());
+            Logger log = Logger.getLogger(HubLauncher.class.getName());
             configureLoggers();
-            LOG.info("Grid Hub preparing to start on port " + port);
+            log.info("Grid Hub preparing to start on port " + port);
             GridHubConfiguration c = GridHubConfiguration.build(args);
             c.setPort(port);
             c.setCapabilityMatcher(new JenkinsCapabilityMatcher(Channel.current(), c.getCapabilityMatcher()));
             Hub hub = new Hub(c);
             hub.start();
-            HubHolder.hub = hub;
+            HubHolder.setHub(hub);
 
             StringBuilder arguments = new StringBuilder();
             for (String arg : args) {
                 arguments.append(" ").append(arg);
             }
-            LOG.info("Grid Hub started on port " + port + " with args:" + arguments.toString());
+            log.info("Grid Hub started on port " + port + " with args:" + arguments.toString());
         } catch (Exception e) {
             Log.error("An error occurred while starting the hub", e);
         }

--- a/src/main/java/hudson/plugins/selenium/HubParamsCallable.java
+++ b/src/main/java/hudson/plugins/selenium/HubParamsCallable.java
@@ -10,9 +10,9 @@ class HubParamsCallable extends MasterToSlaveCallable<HubParams, Throwable> {
 	private static final long serialVersionUID = -4136171068376050199L;
 
 	public HubParams call() throws Throwable {
-		if (HubHolder.hub == null) {
+		if (HubHolder.getHub() == null) {
 			return new HubParams();
 		}
-		return new HubParams(HubHolder.hub.getHost(), HubHolder.hub.getPort(), true);
+		return new HubParams(HubHolder.getHub().getHost(), HubHolder.getHub().getPort(), true);
 	}
 }

--- a/src/main/java/hudson/plugins/selenium/JenkinsCapabilityMatcher.java
+++ b/src/main/java/hudson/plugins/selenium/JenkinsCapabilityMatcher.java
@@ -22,7 +22,25 @@ import java.util.logging.Logger;
  */
 public class JenkinsCapabilityMatcher implements CapabilityMatcher {
 
+    private static final Logger LOGGER = Logger.getLogger(JenkinsCapabilityMatcher.class.getName());
+    /**
+     * Can be used as a capability when WebDriver requests a node from Grid. The value is a boolean expression over labels to select the desired node
+     * to run the test.
+     */
+    public static final String LABEL = "jenkins.label";
+
+    /**
+     * RC uses this to register, to designate its origin.
+     */
+    public static final String NODE_NAME = "jenkins.nodeName";
+
+    /**
+     * Node name of the master computer
+     */
+    public static final String MASTER_NAME = "(master)";
+
     private final CapabilityMatcher base;
+
     private final Channel master;
 
     public JenkinsCapabilityMatcher(Channel master, CapabilityMatcher base) {
@@ -77,34 +95,21 @@ public class JenkinsCapabilityMatcher implements CapabilityMatcher {
         return false;
     }
 
-    /**
-     * Can be used as a capability when WebDriver requests a node from Grid. The value is a boolean expression over labels to select the desired node
-     * to run the test.
-     */
-    public static final String LABEL = "jenkins.label";
-    /**
-     * RC uses this to register, to designate its origin.
-     */
-    public static final String NODE_NAME = "jenkins.nodeName";
-
-    /**
-     * Node name of the master computer
-     */
-    public static final String MASTER_NAME = "(master)";
-
-    /**
-     * Checks if the given node satisfies the label expression.
-     */
     private static class LabelMatcherCallable extends MasterToSlaveCallable<Boolean, ANTLRException> {
 
+        private static final long serialVersionUID = 1L;
+
+        /**
+         * Checks if the given node satisfies the label expression.
+         */
         private final String nodeName;
+
         private final String labelExpr;
 
         public LabelMatcherCallable(String nodeName, String labelExpr) {
             this.nodeName = nodeName.equals(MASTER_NAME) ? "" : nodeName;
             this.labelExpr = labelExpr;
         }
-
         public Boolean call() throws ANTLRException {
             Node n = Jenkins.getInstance().getNode(nodeName);
             if (n == null)
@@ -112,13 +117,10 @@ public class JenkinsCapabilityMatcher implements CapabilityMatcher {
             return Label.parseExpression(labelExpr).matches(n);
         }
 
-        private static final long serialVersionUID = 1L;
     }
 
     public static void enhanceCapabilities(DesiredCapabilities capabilities, String node) {
         String nodeName = StringUtils.isEmpty(node) ? JenkinsCapabilityMatcher.MASTER_NAME : node;
         capabilities.setCapability(JenkinsCapabilityMatcher.NODE_NAME, nodeName);
     }
-
-    private static final Logger LOGGER = Logger.getLogger(JenkinsCapabilityMatcher.class.getName());
 }

--- a/src/main/java/hudson/plugins/selenium/PluginImpl.java
+++ b/src/main/java/hudson/plugins/selenium/PluginImpl.java
@@ -89,6 +89,8 @@ import java.util.logging.Logger;
 @ExportedBean
 public class PluginImpl extends Plugin implements Action, Serializable, Describable<PluginImpl> {
 
+    private static final long serialVersionUID = 1L;
+
     private static final String SEPARATOR = ",";
 
     private static final Logger LOGGER = Logger.getLogger(PluginImpl.class.getName());
@@ -270,6 +272,7 @@ public class PluginImpl extends Plugin implements Action, Serializable, Describa
         HubParams activeHubParams = getCurrentHubParams();
         return activeHubParams.isNotActiveOn(getMasterHostName(), port);
     }
+
     @Exported
     public Integer getActivePort() {
         return getCurrentHubParams().getPort();
@@ -294,7 +297,6 @@ public class PluginImpl extends Plugin implements Action, Serializable, Describa
 
         return result;
     }
-
 
     @Exported
     public boolean getThrowOnCapabilityNotPresent() {
@@ -329,11 +331,11 @@ public class PluginImpl extends Plugin implements Action, Serializable, Describa
             public Collection<SeleniumTestSlotGroup> call() throws RuntimeException {
                 Map<URL, SeleniumTestSlotGroup> groups = new HashMap<URL, SeleniumTestSlotGroup>();
 
-                if (HubHolder.hub == null) {
+                if (HubHolder.getHub() == null) {
                     return Collections.emptyList();
                 }
 
-                Registry registry = HubHolder.hub.getRegistry();
+                Registry registry = HubHolder.getHub().getRegistry();
                 if (registry != null) {
                     for (RemoteProxy proxy : registry.getAllProxies()) {
                         for (TestSlot slot : proxy.getTestSlots()) {
@@ -378,38 +380,35 @@ public class PluginImpl extends Plugin implements Action, Serializable, Describa
 
     @Extension
     public static class DescriptorImpl extends Descriptor<PluginImpl> {
-
         @Override
         public String getDisplayName() {
             return "";
         }
     }
 
-    private static final long serialVersionUID = 1L;
-
     // this part take cares of the migration from 2.0 to 2.1
     public Object readResolve() {
         if (rcFirefoxProfileTemplate != null || rcBrowserSessionReuse != null || rcTrustAllSSLCerts != null || rcBrowserSideLog != null) {
-            String rcFirefoxProfileTemplate_ = getDefaultForNull(rcFirefoxProfileTemplate, "");
-            Boolean rcBrowserSessionReuse_ = getDefaultForNull(rcBrowserSessionReuse, Boolean.FALSE);
-            Boolean rcTrustAllSSLCerts_ = getDefaultForNull(rcTrustAllSSLCerts, Boolean.FALSE);
-            Boolean rcBrowserSideLog_ = getDefaultForNull(rcBrowserSideLog, Boolean.FALSE);
+            String rcFirefoxProfileTemplate = getDefaultForNull(this.rcFirefoxProfileTemplate, "");
+            Boolean rcBrowserSessionReuse = getDefaultForNull(this.rcBrowserSessionReuse, Boolean.FALSE);
+            Boolean rcTrustAllSSLCerts = getDefaultForNull(this.rcTrustAllSSLCerts, Boolean.FALSE);
+            Boolean rcBrowserSideLog = getDefaultForNull(this.rcBrowserSideLog, Boolean.FALSE);
 
             List<SeleniumBrowser> browsers = new ArrayList<SeleniumBrowser>();
             browsers.add(new IEBrowser(5, "", ""));
             browsers.add(new FirefoxBrowser(5, "", ""));
             browsers.add(new ChromeBrowser(5, "", ""));
 
-            int port_ = 4445;
+            int port = 4445;
             try {
                 ServerSocket ss = new ServerSocket(0);
-                port_ = ss.getLocalPort();
+                port = ss.getLocalPort();
                 ss.close();
             } catch (IOException e) {
             }
 
-            SeleniumNodeConfiguration c = new CustomRCConfiguration(port_, rcBrowserSideLog_, rcDebug, rcTrustAllSSLCerts_, rcBrowserSessionReuse_,
-                    -1, rcFirefoxProfileTemplate_, browsers, null);
+            SeleniumNodeConfiguration c = new CustomRCConfiguration(port, rcBrowserSideLog, rcDebug, rcTrustAllSSLCerts, rcBrowserSessionReuse,
+                    -1, rcFirefoxProfileTemplate, browsers, null);
 
             synchronized (configurations) {
                 configurations.add(new SeleniumGlobalConfiguration("Selenium v2.0 configuration", new MatchAllMatcher(), c));

--- a/src/main/java/hudson/plugins/selenium/SeleniumTestSlot.java
+++ b/src/main/java/hudson/plugins/selenium/SeleniumTestSlot.java
@@ -22,6 +22,9 @@ import org.openqa.grid.internal.TestSlot;
 @ExportedBean
 public class SeleniumTestSlot implements Comparable<SeleniumTestSlot>, Serializable {
 
+    private static final long serialVersionUID = 1L;
+
+    private static final Map<String, String> ENV_MAPPING = new HashMap<String, String>();
     /**
      * is anything running?
      */
@@ -71,8 +74,6 @@ public class SeleniumTestSlot implements Comparable<SeleniumTestSlot>, Serializa
             return "Idle";
     }
 
-    private static final Map<String, String> ENV_MAPPING = new HashMap<String, String>();
-
     static {
         ENV_MAPPING.put("*iexplore", "internet explorer");
         ENV_MAPPING.put("*firefox", "firefox");
@@ -96,6 +97,4 @@ public class SeleniumTestSlot implements Comparable<SeleniumTestSlot>, Serializa
             return r;
         return this.getPort() - that.getPort();
     }
-
-    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/hudson/plugins/selenium/callables/RemoteStopSelenium.java
+++ b/src/main/java/hudson/plugins/selenium/callables/RemoteStopSelenium.java
@@ -18,11 +18,11 @@ public class RemoteStopSelenium extends MasterToSlaveCallable<String, Exception>
     private static final long serialVersionUID = -5448989386458342771L;
 
     public String call() throws Exception {
-        Logger LOG = Logger.getLogger(SelfRegisteringRemote.class.getName());
+        Logger log = Logger.getLogger(SelfRegisteringRemote.class.getName());
 
         Logger.getLogger("org").setLevel(Level.ALL);
 
-        LOG.fine("instances " + PropertyUtils.getProperty(SeleniumConstants.PROPERTY_INSTANCE));
+        log.fine("instances " + PropertyUtils.getProperty(SeleniumConstants.PROPERTY_INSTANCE));
         SelfRegisteringRemote srr = PropertyUtils.getProperty(SeleniumConstants.PROPERTY_INSTANCE);
         String url = getRemoteURL(srr);
         srr.stopRemoteServer();

--- a/src/main/java/hudson/plugins/selenium/callables/SeleniumCallable.java
+++ b/src/main/java/hudson/plugins/selenium/callables/SeleniumCallable.java
@@ -22,6 +22,11 @@ import java.util.logging.Logger;
 
 public class SeleniumCallable extends MasterToSlaveFileCallable<String> {
 
+    /**
+     *
+     */
+    private static final long serialVersionUID = 2047557797415325512L;
+
     private static final String ROLE_PARAM = "-role";
 
     private static final String ROLE_NODE_VALUE = "node";
@@ -37,6 +42,7 @@ public class SeleniumCallable extends MasterToSlaveFileCallable<String> {
     private String nodeName;
     private SeleniumRunOptions options;
     private String config;
+
     private TaskListener listener;
 
     private String[] defaultArgs;
@@ -55,11 +61,6 @@ public class SeleniumCallable extends MasterToSlaveFileCallable<String> {
                 ROLE_PARAM, ROLE_NODE_VALUE,
                 HUB_PARAM, "http://" + masterName + ":" + masterPort + "/wd/hub" };
     }
-
-    /**
-	 *
-	 */
-    private static final long serialVersionUID = 2047557797415325512L;
 
     public String invoke(File f, VirtualChannel channel) throws IOException {
         RemoteRunningStatus status = PropertyUtils.getMapProperty(SeleniumConstants.PROPERTY_STATUS, config);

--- a/src/main/java/hudson/plugins/selenium/callables/hub/StopHubCallable.java
+++ b/src/main/java/hudson/plugins/selenium/callables/hub/StopHubCallable.java
@@ -25,14 +25,14 @@ public class StopHubCallable extends MasterToSlaveCallable<Void, Exception> {
      * @see hudson.remoting.Callable#call()
      */
     public Void call() throws Exception {
-	    if (HubHolder.hub == null){
+	    if (HubHolder.getHub() == null){
 		    LOGGER.warning("Hub is not running. Nothing to stop.");
 		    return null;
 	    }
 
-        HubHolder.hub.getRegistry().stop();
-        HubHolder.hub.stop();
-        HubHolder.hub = null;
+        HubHolder.getHub().getRegistry().stop();
+        HubHolder.getHub().stop();
+        HubHolder.setHub(null);
         return null;
     }
 

--- a/src/main/java/hudson/plugins/selenium/configuration/DirectJsonInputConfiguration.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/DirectJsonInputConfiguration.java
@@ -31,6 +31,8 @@ import java.util.logging.Logger;
  */
 public class DirectJsonInputConfiguration extends SeleniumNodeConfiguration {
 
+    private static final Logger LOGGER = Logger.getLogger(FileConfiguration.class.getName());
+
     /**
      *
      */
@@ -157,8 +159,6 @@ public class DirectJsonInputConfiguration extends SeleniumNodeConfiguration {
             return null;
         }
     }
-
-    private static final Logger LOGGER = Logger.getLogger(FileConfiguration.class.getName());
 
     public String getIcon() {
         return "/images/24x24/document.png";

--- a/src/main/java/hudson/plugins/selenium/configuration/FileConfiguration.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/FileConfiguration.java
@@ -17,11 +17,13 @@ import java.util.logging.Logger;
 public class FileConfiguration extends SeleniumNodeConfiguration {
 
     /**
-	 * 
-	 */
-	private static final long serialVersionUID = 5068212020001695128L;
-	
-	private String configURL;
+     *
+     */
+    private static final long serialVersionUID = 5068212020001695128L;
+
+    private static final Logger LOGGER = Logger.getLogger(FileConfiguration.class.getName());
+
+    private String configURL;
 
     @DataBoundConstructor
     public FileConfiguration(String configURL, String display) {
@@ -52,8 +54,8 @@ public class FileConfiguration extends SeleniumNodeConfiguration {
             String fullPath = c.getNode().getRootPath().act(new MasterToSlaveFileCallable<String>() {
 
                 /**
-				 * 
-				 */
+                 *
+                 */
                 private static final long serialVersionUID = -288688398601004624L;
 
                 public String invoke(File f, VirtualChannel channel) throws IOException {
@@ -78,8 +80,6 @@ public class FileConfiguration extends SeleniumNodeConfiguration {
             return null;
         }
     }
-
-    private static final Logger LOGGER = Logger.getLogger(FileConfiguration.class.getName());
 
     public String getIcon() {
         return "/images/24x24/document.png";

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/SeleniumBrowserServerUtils.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/SeleniumBrowserServerUtils.java
@@ -22,9 +22,9 @@ import java.net.URL;
  */
 public final class SeleniumBrowserServerUtils {
 
-    public static String uploadIEDriverIfNecessary(Computer computer, String server_binary) {
-        String server_path = null;
-        if (StringUtils.isBlank(server_binary)) {
+    public static String uploadIEDriverIfNecessary(Computer computer, String serverBinary) {
+        String serverPath = null;
+        if (StringUtils.isBlank(serverBinary)) {
             try {
                 Boolean isWin64bit = computer.getNode().getRootPath().act(new MasterToSlaveFileCallable<Boolean>() {
 
@@ -44,7 +44,7 @@ public final class SeleniumBrowserServerUtils {
                 if (isWin64bit != null) {
                     URL url = SeleniumBrowserServerUtils.class.getClassLoader().getResource("IEDriverServer_" + (isWin64bit ? "64" : "32") + ".exe");
                     final InputStream is = new RemoteInputStream(url.openStream(), RemoteInputStream.Flag.GREEDY);
-                    server_path = computer.getNode().getRootPath().act(new MasterToSlaveFileCallable<String>() {
+                    serverPath = computer.getNode().getRootPath().act(new MasterToSlaveFileCallable<String>() {
 
                         private static final long serialVersionUID = 4508849758404950847L;
 
@@ -60,12 +60,12 @@ public final class SeleniumBrowserServerUtils {
                 }
 
             } catch (Exception e) {
-                server_path = server_binary;
+                serverPath = serverBinary;
             }
         } else {
-            server_path = server_binary;
+            serverPath = serverBinary;
         }
-        return server_path;
+        return serverPath;
     }
 
 }

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/selenium/IEBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/selenium/IEBrowser.java
@@ -21,9 +21,9 @@ public class IEBrowser extends SeleniumBrowser {
     transient private static final String PARAM_BINARY_PATH = "webdriver.ie.driver";
 
     @DataBoundConstructor
-    public IEBrowser(int maxInstances, String version, String server_binary) {
+    public IEBrowser(int maxInstances, String version, String serverBinary) {
         super(maxInstances, version, "*iexplore");
-        this.server_binary = server_binary;
+        this.server_binary = serverBinary;
     }
 
     @Exported
@@ -33,9 +33,9 @@ public class IEBrowser extends SeleniumBrowser {
 
     @Override
     public void initOptions(Computer c, SeleniumRunOptions opt) {
-        String server_path = SeleniumBrowserServerUtils.uploadIEDriverIfNecessary(c, getBinary());
-        if (server_path != null) {
-            opt.getJVMArguments().put(PARAM_BINARY_PATH, server_path);
+        String serverPath = SeleniumBrowserServerUtils.uploadIEDriverIfNecessary(c, getBinary());
+        if (serverPath != null) {
+            opt.getJVMArguments().put(PARAM_BINARY_PATH, serverPath);
         }
         opt.addOptionIfSet("-browser", StringUtils.join(initBrowserOptions(c, opt), ","));
     }

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/ChromeBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/ChromeBrowser.java
@@ -23,8 +23,8 @@ public class ChromeBrowser extends ServerRequiredWebDriverBrowser {
     transient final protected String PARAM_BINARY_PATH = "webdriver.chrome.driver";
 
     @DataBoundConstructor
-    public ChromeBrowser(int maxInstances, String version, String server_binary) {
-        super(maxInstances, version, "chrome", server_binary);
+    public ChromeBrowser(int maxInstances, String version, String serverBinary) {
+        super(maxInstances, version, "chrome", serverBinary);
     }
 
     @Override

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/IEBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/IEBrowser.java
@@ -20,8 +20,8 @@ public class IEBrowser extends ServerRequiredWebDriverBrowser {
     transient private static final String PARAM_BINARY_PATH = "webdriver.ie.driver";
 
     @DataBoundConstructor
-    public IEBrowser(int maxInstances, String version, String server_binary) {
-        super(maxInstances, version, "internet explorer", server_binary);
+    public IEBrowser(int maxInstances, String version, String serverBinary) {
+        super(maxInstances, version, "internet explorer", serverBinary);
     }
 
     @Override
@@ -34,9 +34,9 @@ public class IEBrowser extends ServerRequiredWebDriverBrowser {
 
     @Override
     public void initOptions(Computer c, SeleniumRunOptions opt) {
-        String server_path = SeleniumBrowserServerUtils.uploadIEDriverIfNecessary(c, getServer_binary());
-        if (server_path != null) {
-            opt.getJVMArguments().put(PARAM_BINARY_PATH, server_path);
+        String serverPath = SeleniumBrowserServerUtils.uploadIEDriverIfNecessary(c, getServer_binary());
+        if (serverPath != null) {
+            opt.getJVMArguments().put(PARAM_BINARY_PATH, serverPath);
         }
         opt.addOptionIfSet("-browser", StringUtils.join(initBrowserOptions(c, opt), ","));
     }

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/OperaBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/OperaBrowser.java
@@ -18,9 +18,9 @@ public class OperaBrowser extends WebDriverBrowser {
     private String browser_binary;
 
     @DataBoundConstructor
-    public OperaBrowser(int maxInstances, String version, String browser_binary) {
+    public OperaBrowser(int maxInstances, String version, String browserBinary) {
         super(maxInstances, version, "operablink");
-        this.browser_binary = browser_binary;
+        this.browser_binary = browserBinary;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/ServerRequiredWebDriverBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/ServerRequiredWebDriverBrowser.java
@@ -32,12 +32,12 @@ public abstract class ServerRequiredWebDriverBrowser extends WebDriverBrowser {
      *            Version of the browser to use.
      * @param name
      *            Name of the browser
-     * @param server_binary
+     * @param serverBinary
      *            Path to the server binary that communicate with the real browser
      */
-    protected ServerRequiredWebDriverBrowser(int instances, String version, String name, String server_binary) {
+    protected ServerRequiredWebDriverBrowser(int instances, String version, String name, String serverBinary) {
         super(instances, version, name);
-        this.server_binary = server_binary;
+        this.server_binary = serverBinary;
     }
 
     @Exported

--- a/src/main/java/hudson/plugins/selenium/process/SeleniumJarRunner.java
+++ b/src/main/java/hudson/plugins/selenium/process/SeleniumJarRunner.java
@@ -73,7 +73,7 @@ public abstract class SeleniumJarRunner implements SeleniumProcess {
                     private String remoteUrl = url;
 
                     public Void call() throws Exception {
-                        Registry registry = HubHolder.hub.getRegistry();
+                        Registry registry = HubHolder.getHub().getRegistry();
                         if (registry != null) {
                             Iterator<RemoteProxy> it = registry.getAllProxies().iterator();
                             while (it.hasNext()) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
common-java:DuplicatedBlocks - Source files should not have any duplicated blocks.
squid:S00117 - Local variable and method parameter names should comply with a naming convention.
squid:S1444 - "public static" fields should be constant.
squid:ClassVariableVisibilityCheck - Class variable fields should not have public accessibility.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/common-java:DuplicatedBlocks
https://dev.eclipse.org/sonar/rules/show/squid:S00117
https://dev.eclipse.org/sonar/rules/show/squid:S1444
https://dev.eclipse.org/sonar/rules/show/squid:ClassVariableVisibilityCheck
Please let me know if you have any questions.
George Kankava