### PR TITLE
Multiple code improvements - squid:S1118, squid:S1148, squid:S1210, squid:S1149, squid:CommentedOutCodeLine, squid:S1854, squid:S1155, squid:S1135

### DIFF
--- a/src/main/java/hudson/plugins/selenium/HubHolder.java
+++ b/src/main/java/hudson/plugins/selenium/HubHolder.java
@@ -10,4 +10,6 @@ import org.openqa.grid.web.Hub;
 public class HubHolder {
 
     public static Hub hub;
+
+    private HubHolder() {}
 }

--- a/src/main/java/hudson/plugins/selenium/JenkinsCapabilityMatcher.java
+++ b/src/main/java/hudson/plugins/selenium/JenkinsCapabilityMatcher.java
@@ -48,7 +48,7 @@ public class JenkinsCapabilityMatcher implements CapabilityMatcher {
 
         LOGGER.log(Level.INFO, "NODE : " + reqNode + " - " + nodeName);
 
-        boolean nodeMatch = false;
+        boolean nodeMatch;
 
         if (reqNode != null && nodeName != null) {
             LOGGER.log(Level.INFO, "BOTH NOT NULL");

--- a/src/main/java/hudson/plugins/selenium/PluginImpl.java
+++ b/src/main/java/hudson/plugins/selenium/PluginImpl.java
@@ -490,8 +490,7 @@ public class PluginImpl extends Plugin implements Action, Serializable, Describa
                 try {
                     config.start(c, listener);
                 } catch (ExecutionException e) {
-                    // TODO Auto-generated catch block
-                    e.printStackTrace();
+                    LOGGER.log(Level.SEVERE, e.getMessage(), e);
                 }
             }
         }

--- a/src/main/java/hudson/plugins/selenium/RemoteControlLauncher.java
+++ b/src/main/java/hudson/plugins/selenium/RemoteControlLauncher.java
@@ -10,6 +10,9 @@ import org.openqa.grid.internal.utils.SelfRegisteringRemote;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.server.SeleniumServer;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * Launches Selenium RC.
  *
@@ -20,6 +23,8 @@ import org.openqa.selenium.server.SeleniumServer;
  * @author Richard Lavoie
  */
 public class RemoteControlLauncher extends MasterToSlaveCallable<Void, Exception> {
+
+    private static final Logger LOGGER = Logger.getLogger(RemoteControlLauncher.class.getName());
 
     /**
 	 *
@@ -51,10 +56,10 @@ public class RemoteControlLauncher extends MasterToSlaveCallable<Void, Exception
             Channel.current().waitForProperty(SeleniumConstants.PROPERTY_LOCK);
             return null;
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
             throw e;
         } catch (Error e) {
-            e.printStackTrace();
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
             throw e;
         }
     }

--- a/src/main/java/hudson/plugins/selenium/SeleniumHolder.java
+++ b/src/main/java/hudson/plugins/selenium/SeleniumHolder.java
@@ -6,4 +6,5 @@ public final class SeleniumHolder {
 
     public static SelfRegisteringRemote seleniumInstance;
 
+    private SeleniumHolder() {}
 }

--- a/src/main/java/hudson/plugins/selenium/SeleniumTestSlot.java
+++ b/src/main/java/hudson/plugins/selenium/SeleniumTestSlot.java
@@ -6,6 +6,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 import org.openqa.grid.internal.RemoteProxy;
@@ -95,6 +97,30 @@ public class SeleniumTestSlot implements Comparable<SeleniumTestSlot>, Serializa
         if (r != 0)
             return r;
         return this.getPort() - that.getPort();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SeleniumTestSlot that = (SeleniumTestSlot) o;
+
+        return new EqualsBuilder()
+                .append(isReserved, that.isReserved)
+                .append(host, that.host)
+                .append(capabilities, that.capabilities)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(isReserved)
+                .append(host)
+                .append(capabilities)
+                .toHashCode();
     }
 
     private static final long serialVersionUID = 1L;

--- a/src/main/java/hudson/plugins/selenium/SeleniumTestSlotGroup.java
+++ b/src/main/java/hudson/plugins/selenium/SeleniumTestSlotGroup.java
@@ -10,6 +10,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.kohsuke.stapler.export.Exported;
 import org.kohsuke.stapler.export.ExportedBean;
 
@@ -93,4 +95,25 @@ public class SeleniumTestSlotGroup implements Comparable<SeleniumTestSlotGroup>,
         return this.getPort() - that.getPort();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        SeleniumTestSlotGroup that = (SeleniumTestSlotGroup) o;
+
+        return new EqualsBuilder()
+                .append(host, that.host)
+                .append(slots, that.slots)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(host)
+                .append(slots)
+                .toHashCode();
+    }
 }

--- a/src/main/java/hudson/plugins/selenium/actions/ServiceManagementAction.java
+++ b/src/main/java/hudson/plugins/selenium/actions/ServiceManagementAction.java
@@ -17,8 +17,12 @@ import java.io.OutputStreamWriter;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class ServiceManagementAction implements Action {
+
+    private static final Logger LOGGER = Logger.getLogger(ServiceManagementAction.class.getName());
 
     private Computer computer;
 
@@ -53,7 +57,7 @@ public class ServiceManagementAction implements Action {
         try {
             PluginImpl.startSeleniumNode(computer, new StreamTaskListener(new OutputStreamWriter(System.out)), conf);
         } catch (Exception e) {
-            e.printStackTrace();
+            LOGGER.log(Level.SEVERE, e.getMessage(), e);
         }
         return HttpResponses.forwardToPreviousPage();
     }

--- a/src/main/java/hudson/plugins/selenium/callables/PropertyUtils.java
+++ b/src/main/java/hudson/plugins/selenium/callables/PropertyUtils.java
@@ -10,6 +10,8 @@ public final class PropertyUtils {
 
     private static Map<String, Object> properties = new ConcurrentHashMap<String, Object>();
 
+    private PropertyUtils() {}
+
     public static <T> T getProperty(ChannelProperty<T> property) {
         return property.type.cast(properties.get(property.displayName));
     }

--- a/src/main/java/hudson/plugins/selenium/callables/SeleniumCallable.java
+++ b/src/main/java/hudson/plugins/selenium/callables/SeleniumCallable.java
@@ -65,11 +65,9 @@ public class SeleniumCallable extends MasterToSlaveFileCallable<String> {
         RemoteRunningStatus status = PropertyUtils.getMapProperty(SeleniumConstants.PROPERTY_STATUS, config);
 
         if (status != null && status.isRunning()) {
-            // listener.getLogger().println("Skipping Selenium RC execution because this slave has already started its RCs");
             return null;
         }
 
-        // listener.getLogger().println("Copy grid jar");
         File localSeleniumJar = new File(f, seleniumJar.getName());
         File localHtmlUnitDriverJar = new File(f, htmlUnitDriverJar.getName());
         if (localSeleniumJar.lastModified() != seleniumJarTimestamp) {

--- a/src/main/java/hudson/plugins/selenium/callables/SeleniumConstants.java
+++ b/src/main/java/hudson/plugins/selenium/callables/SeleniumConstants.java
@@ -23,4 +23,6 @@ public class SeleniumConstants {
     public static final String STOPPED = "Stopped";
 
     public static final String ERROR = "Error";
+
+    private SeleniumConstants() {}
 }

--- a/src/main/java/hudson/plugins/selenium/configuration/CustomWDConfiguration.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/CustomWDConfiguration.java
@@ -17,8 +17,12 @@ import org.kohsuke.stapler.export.Exported;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class CustomWDConfiguration extends SeleniumNodeConfiguration {
+
+    private static final Logger LOGGER = Logger.getLogger(CustomWDConfiguration.class.getName());
 
     /**
 	 * 
@@ -101,8 +105,7 @@ public class CustomWDConfiguration extends SeleniumNodeConfiguration {
         try {
             opt.addOptionIfSet("-port", c.getChannel().call(new RetrieveAvailablePort(getPort())));
         } catch (Exception e) {
-            // an error occured, not adding the port option
-            // e.printStackTrace();
+            LOGGER.log(Level.SEVERE, "an error occured, not adding the port option", e);
         }
 
         if (getTimeout() != null && getTimeout() > -1) {

--- a/src/main/java/hudson/plugins/selenium/configuration/SeleniumNodeConfiguration.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/SeleniumNodeConfiguration.java
@@ -53,7 +53,7 @@ public abstract class SeleniumNodeConfiguration extends SeleniumJarRunner implem
     public String getDisplayName() {
         if (displayName == null) {
             String name = getClass().getSimpleName();
-            StringBuffer b = new StringBuffer(name.length());
+            StringBuilder b = new StringBuilder(name.length());
             b.append(name.charAt(0));
             for (int i = 1; i < name.length(); i++) {
                 if (Character.isUpperCase(name.charAt(i))) {

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/SeleniumBrowserServerUtils.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/SeleniumBrowserServerUtils.java
@@ -22,6 +22,8 @@ import java.net.URL;
  */
 public final class SeleniumBrowserServerUtils {
 
+    private SeleniumBrowserServerUtils() {}
+
     public static String uploadIEDriverIfNecessary(Computer computer, String server_binary) {
         String server_path = null;
         if (StringUtils.isBlank(server_binary)) {

--- a/src/main/java/hudson/plugins/selenium/process/SeleniumProcessUtils.java
+++ b/src/main/java/hudson/plugins/selenium/process/SeleniumProcessUtils.java
@@ -33,6 +33,8 @@ public final class SeleniumProcessUtils {
 
 	private static final Logger LOGGER = Logger.getLogger(SeleniumProcessUtils.class.getName());
 
+    private SeleniumProcessUtils() {}
+
     /**
      * Locate the stand-alone server jar from the classpath. Only works on the master.
      */


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1118 - Utility classes should not have public constructors.
squid:S1148 - Throwable.printStackTrace(...) should not be called.
squid:S1210 - "equals(Object obj)" should be overridden along with the "compareTo(T obj)" method.
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:CommentedOutCodeLine - Sections of code should not be "commented out".
squid:S1854 - Dead stores should be removed.
squid:S1155 - Collection.isEmpty() should be used to test for emptiness.
squid:S1135 - "TODO" tags should be handled.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:S1148
https://dev.eclipse.org/sonar/rules/show/squid:S1210
https://dev.eclipse.org/sonar/rules/show/squid:S1149
https://dev.eclipse.org/sonar/rules/show/squid:CommentedOutCodeLine
https://dev.eclipse.org/sonar/rules/show/squid:S1854
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1135
Please let me know if you have any questions.
George Kankava