### PR TITLE
Multiple code improvements - squid:S00116, squid:S2583, squid:RedundantThrowsDeclarationCheck, squid:S00100, squid:S1068, squid:S1848, squid:S1488, squid:S00122, squid:UselessParenthesesCheck

### DIFF
--- a/src/main/java/hudson/plugins/selenium/PluginImpl.java
+++ b/src/main/java/hudson/plugins/selenium/PluginImpl.java
@@ -121,7 +121,6 @@ public class PluginImpl extends Plugin implements Action, Serializable, Describa
     private transient Boolean rcTrustAllSSLCerts;
     private transient Boolean rcBrowserSideLog;
     private transient boolean rcDebug;
-    private transient String rcLog;
 
     private final List<SeleniumGlobalConfiguration> configurations = new ArrayList<SeleniumGlobalConfiguration>();
 
@@ -284,7 +283,9 @@ public class PluginImpl extends Plugin implements Action, Serializable, Describa
 
     public HubParams getCurrentHubParams() {
         HubParams result = new HubParams();
-        if (channel == null) return result;
+        if (channel == null) {
+            return result;
+        }
 
         try {
             return channel.call(new HubParamsCallable());
@@ -319,14 +320,14 @@ public class PluginImpl extends Plugin implements Action, Serializable, Describa
         if (channel == null)
             return Collections.emptyList();
 
-        Collection<SeleniumTestSlotGroup> rcs = channel.call(new MasterToSlaveCallable<Collection<SeleniumTestSlotGroup>, RuntimeException>() {
+        return channel.call(new MasterToSlaveCallable<Collection<SeleniumTestSlotGroup>, RuntimeException>() {
 
             /**
              *
              */
             private static final long serialVersionUID = 1791985298575049757L;
 
-            public Collection<SeleniumTestSlotGroup> call() throws RuntimeException {
+            public Collection<SeleniumTestSlotGroup> call() {
                 Map<URL, SeleniumTestSlotGroup> groups = new HashMap<URL, SeleniumTestSlotGroup>();
 
                 if (HubHolder.hub == null) {
@@ -353,7 +354,6 @@ public class PluginImpl extends Plugin implements Action, Serializable, Describa
                 return values;
             }
         });
-        return rcs;
 
     }
 

--- a/src/main/java/hudson/plugins/selenium/callables/StopSeleniumServer.java
+++ b/src/main/java/hudson/plugins/selenium/callables/StopSeleniumServer.java
@@ -41,7 +41,7 @@ public class StopSeleniumServer extends MasterToSlaveCallable<String, Exception>
     }
 
     private RemoteRunningStatus getRunningStatus() {
-        return ((RemoteRunningStatus) PropertyUtils.getMapProperty(SeleniumConstants.PROPERTY_STATUS, name));
+        return (RemoteRunningStatus) PropertyUtils.getMapProperty(SeleniumConstants.PROPERTY_STATUS, name);
     }
 
     private <T, V extends Exception> T callOnSubProcess(Callable<T, V> call, T defaultValue) throws Exception {

--- a/src/main/java/hudson/plugins/selenium/configuration/DirectJsonInputConfiguration.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/DirectJsonInputConfiguration.java
@@ -91,7 +91,6 @@ public class DirectJsonInputConfiguration extends SeleniumNodeConfiguration {
                 return notEmpty;
             }
             try {
-                new JSONObject(config);
                 // We don't want to validate the fields, even RegistrationRequest doesn't ... It just ignores the unknown fields.
                 return FormValidation.ok();
             } catch (Exception e) {

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/AbstractSeleniumBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/AbstractSeleniumBrowser.java
@@ -24,13 +24,13 @@ public abstract class AbstractSeleniumBrowser<T extends AbstractSeleniumBrowser<
 	 */
     private static final long serialVersionUID = -1895158524568642537L;
 
-    transient protected final String PARAM_BROWSER_NAME = "browserName";
+    transient protected final String paramBrowserName = "browserName";
 
-    transient protected final String PARAM_MAX_INSTANCES = "maxInstances";
+    transient protected final String paramMaxInstances = "maxInstances";
 
-    transient protected final String PARAM_VERSION = "version";
+    transient protected final String paramVersion = "version";
 
-    transient protected final String PARAM_SELENIUM_PROTOCOL = "seleniumProtocol";
+    transient protected final String paramSeleniumProtocol = "seleniumProtocol";
 
     private int maxInstances = 0;
     private String version;
@@ -97,10 +97,10 @@ public abstract class AbstractSeleniumBrowser<T extends AbstractSeleniumBrowser<
 
     protected List<String> initBrowserOptions(Computer c, SeleniumRunOptions options) {
         List<String> args = new ArrayList<String>();
-        combine(args, PARAM_SELENIUM_PROTOCOL, protocol);
-        combine(args, PARAM_BROWSER_NAME, getName());
-        combine(args, PARAM_MAX_INSTANCES, maxInstances);
-        combine(args, PARAM_VERSION, version);
+        combine(args, paramSeleniumProtocol, protocol);
+        combine(args, paramBrowserName, getName());
+        combine(args, paramMaxInstances, maxInstances);
+        combine(args, paramVersion, version);
         return args;
     }
 

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/selenium/ChromeBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/selenium/ChromeBrowser.java
@@ -18,7 +18,7 @@ public class ChromeBrowser extends SeleniumBrowser {
 	 */
     private static final long serialVersionUID = -7028484889764200348L;
 
-    transient final protected String PARAM_BINARY_PATH = "webdriver.chrome.driver";
+    transient final protected String paramBinaryPath = "webdriver.chrome.driver";
 
     private String binary;
 
@@ -36,7 +36,7 @@ public class ChromeBrowser extends SeleniumBrowser {
     @Override
     public Map<String, String> getJVMArgs() {
         Map<String, String> args = new HashMap<String, String>();
-        combine(args, PARAM_BINARY_PATH, binary);
+        combine(args, paramBinaryPath, binary);
         return args;
     }
 

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/selenium/FirefoxBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/selenium/FirefoxBrowser.java
@@ -16,25 +16,25 @@ public class FirefoxBrowser extends SeleniumBrowser {
 	 */
     private static final long serialVersionUID = 1180910636911313608L;
 
-    transient final protected String PARAM_BINARY_PATH = "firefox_binary";
+    transient final protected String paramBinaryPath = "firefox_binary";
 
-    private String binary_path;
+    private String binaryPath;
 
     @DataBoundConstructor
     public FirefoxBrowser(int maxInstances, String version, String binaryPath) {
         super(maxInstances, version, "*firefox");
-        this.binary_path = binaryPath;
+        this.binaryPath = binaryPath;
     }
 
     @Exported
     public String getBinaryPath() {
-        return binary_path;
+        return binaryPath;
     }
 
     @Override
     public List<String> initBrowserOptions(Computer c, SeleniumRunOptions options) {
         List<String> args = super.initBrowserOptions(c, options);
-        combine(args, PARAM_BINARY_PATH, binary_path);
+        combine(args, paramBinaryPath, binaryPath);
         return args;
     }
 

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/selenium/IEBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/selenium/IEBrowser.java
@@ -16,19 +16,19 @@ public class IEBrowser extends SeleniumBrowser {
 	 */
     private static final long serialVersionUID = 1128527306600780412L;
 
-    private String server_binary;
+    private String serverBinary;
 
     transient private static final String PARAM_BINARY_PATH = "webdriver.ie.driver";
 
     @DataBoundConstructor
     public IEBrowser(int maxInstances, String version, String server_binary) {
         super(maxInstances, version, "*iexplore");
-        this.server_binary = server_binary;
+        this.serverBinary = server_binary;
     }
 
     @Exported
     public String getBinary() {
-        return server_binary;
+        return serverBinary;
     }
 
     @Override

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/selenium/OperaBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/selenium/OperaBrowser.java
@@ -15,7 +15,7 @@ public class OperaBrowser extends SeleniumBrowser {
 	 */
     private static final long serialVersionUID = -7520649475709638350L;
 
-    transient final protected String PARAM_BINARY_PATH = "opera.binary";
+    transient final protected String paramBinaryPath = "opera.binary";
 
     private String binary;
 
@@ -33,7 +33,7 @@ public class OperaBrowser extends SeleniumBrowser {
     @Override
     public Map<String, String> getJVMArgs() {
         Map<String, String> args = new HashMap<String, String>();
-        combine(args, PARAM_BINARY_PATH, binary);
+        combine(args, paramBinaryPath, binary);
         return args;
     }
 

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/ChromeBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/ChromeBrowser.java
@@ -20,7 +20,7 @@ public class ChromeBrowser extends ServerRequiredWebDriverBrowser {
     /**
      * System property to specify the chrome binary location. Could be done through a tool installer and probably moved into the chromedriver plugin.
      */
-    transient final protected String PARAM_BINARY_PATH = "webdriver.chrome.driver";
+    transient final protected String paramBinaryPath = "webdriver.chrome.driver";
 
     @DataBoundConstructor
     public ChromeBrowser(int maxInstances, String version, String server_binary) {
@@ -30,7 +30,7 @@ public class ChromeBrowser extends ServerRequiredWebDriverBrowser {
     @Override
     public Map<String, String> getJVMArgs() {
         Map<String, String> args = new HashMap<String, String>();
-        combine(args, PARAM_BINARY_PATH, getServer_binary());
+        combine(args, paramBinaryPath, getServerBinary());
         return args;
     }
 

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/FirefoxBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/FirefoxBrowser.java
@@ -16,25 +16,25 @@ public class FirefoxBrowser extends WebDriverBrowser {
 	 */
     private static final long serialVersionUID = 1451746845341944745L;
 
-    transient final protected String PARAM_BINARY_PATH = "firefox_binary";
+    transient final protected String paramBinaryPath = "firefox_binary";
 
-    private String binary_path;
+    private String binaryPath;
 
     @DataBoundConstructor
     public FirefoxBrowser(int maxInstances, String version, String binaryPath) {
         super(maxInstances, version, "firefox");
-        binary_path = binaryPath;
+        this.binaryPath = binaryPath;
     }
 
     @Exported
     public String getBinaryPath() {
-        return binary_path;
+        return binaryPath;
     }
 
     @Override
     public List<String> initBrowserOptions(Computer c, SeleniumRunOptions options) {
         List<String> args = super.initBrowserOptions(c, options);
-        combine(args, PARAM_BINARY_PATH, binary_path);
+        combine(args, paramBinaryPath, binaryPath);
         return args;
     }
 

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/IEBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/IEBrowser.java
@@ -28,13 +28,13 @@ public class IEBrowser extends ServerRequiredWebDriverBrowser {
     public Map<String, String> getJVMArgs() {
         Map<String, String> args = new HashMap<String, String>();
 
-        combine(args, PARAM_BINARY_PATH, getServer_binary());
+        combine(args, PARAM_BINARY_PATH, getServerBinary());
         return args;
     }
 
     @Override
     public void initOptions(Computer c, SeleniumRunOptions opt) {
-        String server_path = SeleniumBrowserServerUtils.uploadIEDriverIfNecessary(c, getServer_binary());
+        String server_path = SeleniumBrowserServerUtils.uploadIEDriverIfNecessary(c, getServerBinary());
         if (server_path != null) {
             opt.getJVMArguments().put(PARAM_BINARY_PATH, server_path);
         }

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/OperaBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/OperaBrowser.java
@@ -13,20 +13,20 @@ public class OperaBrowser extends WebDriverBrowser {
 	 */
     private static final long serialVersionUID = -5094330146488965759L;
 
-    transient final protected String PARAM_BINARY_PATH = "opera.binary";
+    transient final protected String paramBinaryPath = "opera.binary";
 
-    private String browser_binary;
+    private String browserBinary;
 
     @DataBoundConstructor
     public OperaBrowser(int maxInstances, String version, String browser_binary) {
         super(maxInstances, version, "operablink");
-        this.browser_binary = browser_binary;
+        this.browserBinary = browser_binary;
     }
 
     @Override
     public Map<String, String> getJVMArgs() {
         Map<String, String> args = new HashMap<String, String>();
-        combine(args, PARAM_BINARY_PATH, browser_binary);
+        combine(args, paramBinaryPath, browserBinary);
         return args;
     }
 

--- a/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/ServerRequiredWebDriverBrowser.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/browser/webdriver/ServerRequiredWebDriverBrowser.java
@@ -22,7 +22,7 @@ public abstract class ServerRequiredWebDriverBrowser extends WebDriverBrowser {
     /**
      * Path to the server binary used to communicate with the browser.
      */
-    private String server_binary;
+    private String serverBinary;
 
     /**
      * 
@@ -37,11 +37,11 @@ public abstract class ServerRequiredWebDriverBrowser extends WebDriverBrowser {
      */
     protected ServerRequiredWebDriverBrowser(int instances, String version, String name, String server_binary) {
         super(instances, version, name);
-        this.server_binary = server_binary;
+        this.serverBinary = server_binary;
     }
 
     @Exported
-    public String getServer_binary() {
-        return server_binary;
+    public String getServerBinary() {
+        return serverBinary;
     }
 }

--- a/src/main/java/hudson/plugins/selenium/process/SeleniumProcessUtils.java
+++ b/src/main/java/hudson/plugins/selenium/process/SeleniumProcessUtils.java
@@ -85,8 +85,7 @@ public final class SeleniumProcessUtils {
         vmb.classpath().addJarOf(Channel.class);
         vmb.mainClass(Launcher.class);
 
-        if (classpath != null)
-            vmb.args().add("-cp").add(classpath);
+        vmb.args().add("-cp").add(classpath);
         vmb.args().add("-connectTo", "localhost:" + serverSocket.getLocalPort());
 
         // TODO add XVFB options here


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00116 - Field names should comply with a naming convention.
squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE".
squid:RedundantThrowsDeclarationCheck - Throws declarations should not be superfluous.
squid:S00100 - Method names should comply with a naming convention.
squid:S1068 - Unused private fields should be removed.
squid:S1848 - Objects should not be created to be dropped immediately without being used.
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S00122 - Statements should be on separate lines.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00116
https://dev.eclipse.org/sonar/rules/show/squid:S2583
https://dev.eclipse.org/sonar/rules/show/squid:RedundantThrowsDeclarationCheck
https://dev.eclipse.org/sonar/rules/show/squid:S00100
https://dev.eclipse.org/sonar/rules/show/squid:S1068
https://dev.eclipse.org/sonar/rules/show/squid:S1848
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S00122
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
George Kankava