### PR TITLE
Fix issue where Selenium admin permission wasn't honored in UI 

### DIFF
--- a/src/main/resources/hudson/plugins/selenium/PluginImpl/conf_sidepanel.jelly
+++ b/src/main/resources/hudson/plugins/selenium/PluginImpl/conf_sidepanel.jelly
@@ -3,7 +3,7 @@
     <l:side-panel>
         <l:tasks>
             <l:task icon="images/24x24/up.png" href="${rootURL}/selenium" title="${%Plugin home}"/>
-            <j:if test="${app.isAdmin()}">
+            <j:if test="${it.isAdmin()}">
                 <l:task icon="images/24x24/setting.png" href="${rootURL}/selenium/configurations"
                         title="${%Configurations}"/>
                 <l:task icon="images/24x24/computer.png" href="${rootURL}/selenium/computers"

--- a/src/main/resources/hudson/plugins/selenium/PluginImpl/index.jelly
+++ b/src/main/resources/hudson/plugins/selenium/PluginImpl/index.jelly
@@ -23,7 +23,7 @@
         </script>
         <st:include page="sidepanel.jelly"/>
         <l:main-panel>
-            <j:if test="${app.isAdmin()}">
+            <j:if test="${it.isAdmin()}">
                 <h2>${%Hub management}</h2>
                 <form method="post" action="${prefix}restart">
                     <f:submit value="${%Restart}"/>

--- a/src/main/resources/hudson/plugins/selenium/PluginImpl/sidepanel.jelly
+++ b/src/main/resources/hudson/plugins/selenium/PluginImpl/sidepanel.jelly
@@ -5,7 +5,7 @@
         <l:tasks>
             <l:task icon="images/24x24/up.gif" href=".." title="${%Back to Dashboard}"/>
             <l:task icon="images/24x24/search.gif" href="." title="${%Status}"/>
-            <j:if test="${app.isAdmin()}">
+            <j:if test="${it.isAdmin()}">
                 <l:task icon="images/24x24/setting.png" href="configurations" title="${%Configurations}"/>
             </j:if>
             <l:task icon="images/24x24/terminal.gif" href="console" title="${%Console Output}"/>

--- a/src/main/resources/hudson/plugins/selenium/configuration/global/SeleniumGlobalConfiguration/sidepanel.jelly
+++ b/src/main/resources/hudson/plugins/selenium/configuration/global/SeleniumGlobalConfiguration/sidepanel.jelly
@@ -3,7 +3,7 @@
     <l:side-panel>
         <l:tasks>
             <l:task icon="plugin/selenium/24x24/selenium.png" href="${rootURL}/selenium" title="${%Plugin home}"/>
-            <j:if test="${app.isAdmin()}">
+            <j:if test="${it.isAdmin()}">
                 <l:task icon="images/24x24/up.png" href="${rootURL}/selenium/configurations"
                         title="${%Back to list of configurations}"/>
                 <l:task icon="images/24x24/setting.png" href="." title="${%Configure}"/>


### PR DESCRIPTION
The jelly files were using the isAdmin from the built-in Hudson object instead of the one defined in the PluginImpl.  That means the Selenium Admin permission wasn't being honored correctly.

See https://issues.jenkins-ci.org/browse/JENKINS-31260 for an example of the issue
