### PR TITLE
Add -sessionTimeout web driver node option

### DIFF
--- a/src/main/java/hudson/plugins/selenium/PluginImpl.java
+++ b/src/main/java/hudson/plugins/selenium/PluginImpl.java
@@ -654,7 +654,7 @@ public class PluginImpl extends Plugin implements Action, Serializable, Describa
         browsers.add(new hudson.plugins.selenium.configuration.browser.webdriver.IEBrowser(1, null, null, false));
         browsers.add(new hudson.plugins.selenium.configuration.browser.webdriver.FirefoxBrowser(5, null, null));
         browsers.add(new hudson.plugins.selenium.configuration.browser.webdriver.ChromeBrowser(5, null, null));
-        return new CustomWDConfiguration(4445, null, browsers, null, 5);
+        return new CustomWDConfiguration(4445, null, browsers, null, 5, 60);
     }
 
     /**

--- a/src/main/java/hudson/plugins/selenium/configuration/CustomWDConfiguration.java
+++ b/src/main/java/hudson/plugins/selenium/configuration/CustomWDConfiguration.java
@@ -31,6 +31,7 @@ public class CustomWDConfiguration extends SeleniumNodeConfiguration {
 
 	private int port = 4444;
     private Integer maxSession = 5;
+    private Integer sessionTimeout = 60;
     private Integer timeout = -1;
 
     private List<WebDriverBrowser> browsers = new ArrayList<WebDriverBrowser>();
@@ -43,12 +44,13 @@ public class CustomWDConfiguration extends SeleniumNodeConfiguration {
     }
 
     @DataBoundConstructor
-    public CustomWDConfiguration(int port, Integer timeout, List<WebDriverBrowser> browsers, String display, Integer maxSession) {
+    public CustomWDConfiguration(int port, Integer timeout, List<WebDriverBrowser> browsers, String display, Integer maxSession, Integer sessionTimeout) {
         super(display);
         this.port = port;
         this.timeout = timeout;
         this.browsers = browsers;
         this.maxSession = maxSession;
+        this.sessionTimeout = sessionTimeout;
     }
 
     @Exported
@@ -63,6 +65,9 @@ public class CustomWDConfiguration extends SeleniumNodeConfiguration {
 
     @Exported
     public Integer getMaxSession() { return maxSession; }
+
+    @Exported
+    public Integer getSessionTimeout() { return sessionTimeout; }
 
     @Exported
     public List<WebDriverBrowser> getBrowsers() {
@@ -131,6 +136,11 @@ public class CustomWDConfiguration extends SeleniumNodeConfiguration {
         if (getMaxSession() != null && getMaxSession() > 0) {
             opt.addOption("-maxSession");
             opt.addOption(getMaxSession().toString());
+        }
+
+        if (getSessionTimeout() != null && getSessionTimeout() >= 60) {
+            opt.addOption("-sessionTimeout");
+            opt.addOption(getSessionTimeout().toString());
         }
 
         for (WebDriverBrowser b : browsers) {

--- a/src/main/resources/hudson/plugins/selenium/configuration/CustomWDConfiguration/config.jelly
+++ b/src/main/resources/hudson/plugins/selenium/configuration/CustomWDConfiguration/config.jelly
@@ -7,6 +7,9 @@
     <f:entry title="${%Max node sessions}" field="maxSession">
         <f:textbox/>
     </f:entry>
+    <f:entry title="${%Session timeout}" field="sessionTimeout">
+        <f:textbox value="${sessionTimeout}"/>
+    </f:entry>
     <f:entry title="${%X11 display}" field="display">
         <f:textbox value="${display}"/>
     </f:entry>

--- a/src/test/java/hudson/plugins/selenium/SeleniumTest.java
+++ b/src/test/java/hudson/plugins/selenium/SeleniumTest.java
@@ -46,7 +46,7 @@ public class SeleniumTest {
         browsers.add(new OperaBrowser(1, "", ""));
         browsers.add(new EdgeBrowser(1, "", ""));
 
-        CustomWDConfiguration cc = new CustomWDConfiguration(5000, -1, browsers, null, 5);
+        CustomWDConfiguration cc = new CustomWDConfiguration(5000, -1, browsers, null, 5, 60);
         addConfiguration("customWD", new NodeLabelMatcher("label-node"), cc);
         j.createSlave("label-node", "label-node", null);
 
@@ -85,7 +85,7 @@ public class SeleniumTest {
         List<WebDriverBrowser> browsers = new ArrayList<WebDriverBrowser>();
         browsers.add(new HTMLUnitBrowser(10));
 
-        CustomWDConfiguration cc = new CustomWDConfiguration(5001, -1, browsers, null, 5);
+        CustomWDConfiguration cc = new CustomWDConfiguration(5001, -1, browsers, null, 5, 60);
         addConfiguration("test", new NodeLabelMatcher("foolabel"), cc);
         j.createSlave("foo", "foolabel", null);
 
@@ -171,7 +171,7 @@ public class SeleniumTest {
         List<WebDriverBrowser> browsers = new ArrayList<WebDriverBrowser>();
         browsers.add(new HTMLUnitBrowser(1));
 
-        CustomWDConfiguration cc = new CustomWDConfiguration(5002, -1, browsers, null, 5);
+        CustomWDConfiguration cc = new CustomWDConfiguration(5002, -1, browsers, null, 5, 60);
 
         getPlugin().getGlobalConfigurations().add(new SeleniumGlobalConfiguration("test", new NodeLabelMatcher("foolabel"), cc));
         j.createSlave("foo", "foolabel", null);


### PR DESCRIPTION
Hi, I wanted the "-sessionTimetout" option to my nodes that used the "Custom web driver node configuration", but noticed there was only "Preferred port", "Max node sessions" and "X11 display"  as options.

So I added the code to have the additional "-sessionTimetout" option.

It works for me, but I don't know if it's optimal. I have put 60 as minimal value, but there's no error shown on the interface if you put a value less than that. Also, maybe 60 is not ideal either.

I did this pull request quite fast... I'm letting you optimize it if you want.

Thanks.